### PR TITLE
RoI Model and Revision

### DIFF
--- a/src/rcnn/box/__init__.py
+++ b/src/rcnn/box/__init__.py
@@ -1,14 +1,16 @@
 """Box Module."""
 from src.rcnn.box import bbox
 from src.rcnn.box import delta
-from src.rcnn.box._anchor import anchor
+from src.rcnn.box._anchor import abs_anchors
+from src.rcnn.box._anchor import anchors
 from src.rcnn.box._utils import bbox2delta
 from src.rcnn.box._utils import delta2bbox
 
 __all__ = [
     "bbox",
     "delta",
-    "anchor",
+    "abs_anchors",
+    "anchors",
     "bbox2delta",
     "delta2bbox",
 ]

--- a/src/rcnn/box/bbox.py
+++ b/src/rcnn/box/bbox.py
@@ -273,3 +273,24 @@ def to_xywh(bbox: tf.Tensor) -> tf.Tensor:
     """
     xywh = tf.stack([xctr(bbox), yctr(bbox), w(bbox), h(bbox)], axis=-1)
     return tf.concat([xywh, rem(bbox)], axis=-1)
+
+
+def clip(bbox: tf.Tensor, h: float, w: float) -> tf.Tensor:
+    """Clip bounding box to a given image shape.
+
+    Args:
+        bbox (tf.Tensor): bounding box tensor (YXYX) of shape
+            (N1, N2, ..., Nk, C) where C >= 4
+        h (float): image height
+        w (float): image width
+
+    Returns:
+        tf.Tensor: clipped bounding box tensor (YXYX) of shape
+            (N1, N2, ..., Nk, C)
+    """
+    ymin_ = tf.clip_by_value(ymin(bbox), 0.0, h)
+    xmin_ = tf.clip_by_value(xmin(bbox), 0.0, w)
+    ymax_ = tf.clip_by_value(ymax(bbox), 0.0, h)
+    xmax_ = tf.clip_by_value(xmax(bbox), 0.0, w)
+    yxyx = tf.stack([ymin_, xmin_, ymax_, xmax_], axis=-1)
+    return tf.concat([yxyx, rem(bbox)], axis=-1)

--- a/src/rcnn/config.py
+++ b/src/rcnn/config.py
@@ -54,6 +54,7 @@ class Config:
     STRIDE = 32
     W = 416  # original image width
     H = 416  # original image height
+    C = 3  # number of channels
     W_FM = W // STRIDE  # feature map width
     H_FM = H // STRIDE  # feature map height
     N_ANCHOR = 9  # number of anchors per grid cell

--- a/src/rcnn/model/__init__.py
+++ b/src/rcnn/model/__init__.py
@@ -1,8 +1,10 @@
 """Model package."""
-from src.rcnn.model._model import mdl_rpn
-from src.rcnn.model._rpn import RPN
+from src.rcnn.model._model import get_roi_model
+from src.rcnn.model._model import get_rpn_model
+from src.rcnn.model._proposal import ProposalBlock
 
 __all__ = [
-    "mdl_rpn",
-    "RPN",
+    "get_roi_model",
+    "get_rpn_model",
+    "ProposalBlock",
 ]

--- a/src/rcnn/model/_model.py
+++ b/src/rcnn/model/_model.py
@@ -4,21 +4,35 @@ from tensorflow.keras.layers import Input
 from tensorflow.keras.models import Model
 
 from src.rcnn import cfg
-from src.rcnn.model._rpn import RPN
+from src.rcnn.model._proposal import ProposalBlock
+from src.rcnn.model._roi import RoiBlock
 
 __all__ = [
-    "mdl_rpn",
+    "get_rpn_model",
+    "get_roi_model",
 ]
 
 
 def get_rpn_model() -> Model:
-    layer_in = Input(shape=(cfg.H, cfg.W, 3))
+    layer_in = Input(shape=(cfg.H, cfg.W, cfg.C))
     vgg = VGG16(include_top=False)
-    rpn = RPN()
-    vgg_out = vgg(layer_in)
-    rpn_out = rpn(vgg_out)
-    mdl = Model(inputs=layer_in, outputs=rpn_out)
+    rpn = ProposalBlock()
+    feature_map = vgg(layer_in)
+    rpn_box, rpn_cls = rpn(feature_map)
+    mdl = Model(inputs=layer_in, outputs=[rpn_box, rpn_cls])
     return mdl
 
 
-mdl_rpn = get_rpn_model()
+def get_roi_model() -> Model:
+    n_score = 1000
+    n_nms = 100
+    nms_th = 0.7
+    layer_in = Input(shape=(cfg.H, cfg.W, cfg.C))
+    vgg = VGG16(include_top=False)
+    rpn = ProposalBlock()
+    feature_map = vgg(layer_in)
+    rpn_box, rpn_cls = rpn(feature_map)
+    roi = RoiBlock(n_score, n_nms, nms_th)
+    roi_box = roi(rpn_cls, rpn_box)
+    mdl = Model(inputs=layer_in, outputs=roi_box)
+    return mdl

--- a/src/rcnn/model/_proposal.py
+++ b/src/rcnn/model/_proposal.py
@@ -1,12 +1,12 @@
-"""Region Proposal Network (RPN) for Faster R-CNN."""
+"""Region Proposal Block."""
 import tensorflow as tf
 from tensorflow.keras.layers import Conv2D
 
 from src.rcnn import cfg
 
 
-class RPN(tf.keras.Model):
-    """Region Proposal Network (RPN) for Faster R-CNN.
+class ProposalBlock(tf.keras.Model):
+    """Region Proposal Block.
 
     It accepts a feature map from a backbone network as input and outputs
     bounding box regression predictions and classification predictions.
@@ -37,15 +37,15 @@ class RPN(tf.keras.Model):
                                 activation="sigmoid",
                                 name="rpn_cls")
 
-    def call(self, inputs: tf.Tensor) -> list[tf.Tensor]:
+    def call(self, inputs: tf.Tensor) -> tuple[tf.Tensor, tf.Tensor]:
         """Forward pass.
 
         Args:
             inputs (tf.Tensor): Feature map from the backbone network.
 
         Returns:
-            list[tf.Tensor]: Bounding box regression predictions and
-            classification predictions.
+            tuple[tf.Tensor, tf.Tensor]: Bounding box regression predictions
+            and classification predictions.
             The first tensor has shape [n_batch, N, 4] and the second tensor
             has shape [n_batch, N, 1], where `N` is the number of all anchors
             in the feature map.
@@ -56,7 +56,7 @@ class RPN(tf.keras.Model):
         shared = self._conv2d(inputs)  # Shared convolutional base
         box_reg = self.reg_layer(shared)  # coordinate regression
         lbl_cls = self.cls_layer(shared)  # label classification
-        return [
+        return (
             tf.reshape(box_reg, (n_batch, -1, 4)),  # [n_batch, N, 4]
             tf.reshape(lbl_cls, (n_batch, -1, 1)),  # [n_batch, N, 1]
-        ]
+        )

--- a/src/rcnn/model/_roi.py
+++ b/src/rcnn/model/_roi.py
@@ -1,0 +1,67 @@
+"""Region of Interest (RoI) Block."""
+import tensorflow as tf
+
+from src.rcnn import box
+
+
+class RoiBlock(tf.keras.Model):
+    """RoI Block.
+
+    It receives the RPN class and bounding box predictions and produces Region
+    of Interests (RoI).
+    """
+
+    def __init__(self, n_score: int, n_nms: int, nms_th: float, **kwargs):
+        """Initialize the Block.
+
+        Args:
+            n_score (int): number of top scores to keep.
+            n_nms (int): number of RoIs to keep after NMS.
+            nms_th (float): NMS threshold.
+            kwargs: Other keyword arguments passed to the parent class.
+        """
+        super().__init__(**kwargs)
+        self._n_score = n_score
+        self._n_nms = n_nms
+        self._nms_th = nms_th
+
+    def get_roi(self, rpn_prob: tf.Tensor, rpn_del: tf.Tensor) -> tf.Tensor:
+        """Get proposed Region of Interests (RoIs) of a single image.
+
+        Args:
+            rpn_prob (tf.Tensor): RPN classification predictions.
+                Shape [N_ac, 1].
+            rpn_del (tf.Tensor): RPN bounding box delta predictions.
+                Shape [N_ac, 4].
+
+        Returns:
+            tf.Tensor: proposed Region of Interests (RoIs).
+        """
+        scores = tf.squeeze(rpn_prob, axis=-1)  # (N_ac,)
+        top_score_idx = tf.math.top_k(scores, k=self._n_score).indices
+        top_score = tf.gather(scores, top_score_idx)  # (n_score,)
+        top_delta = tf.gather(rpn_del, top_score_idx)  # (n_score, 4)
+        top_ac = tf.gather(box.anchors, top_score_idx)  # (n_score, 4)
+        rois_all = box.bbox2delta(top_ac, top_delta)  # (n_score, 4)
+        # clip
+        rois = box.bbox.clip(rois_all, 1., 1.)  # (n_score, 4)
+        # nms
+        nms_idx = tf.image.non_max_suppression(rois, top_score, self._n_nms,
+                                               self._nms_th)  # (n_nms,)
+        rois = tf.gather(rois, nms_idx)  # (n_nms, 4)
+        return rois
+
+    def call(self, rpn_prob: tf.Tensor, rpn_del: tf.Tensor) -> tf.Tensor:
+        """Get proposed Region of Interests (RoIs) of a batch of images.
+
+        Args:
+            rpn_prob (tf.Tensor): RPN classification predictions.
+                Shape [B, N_ac, 1].
+            rpn_del (tf.Tensor): RPN bounding box delta predictions.
+                Shape [B, N_ac, 4].
+
+        Returns:
+            tf.Tensor: proposed Region of Interests (RoIs) [B, n_nms, 4]
+        """
+        rois = tf.map_fn(self.get_roi, (rpn_prob, rpn_del), dtype=tf.float32)
+        return rois

--- a/src/rcnn/trainer.py
+++ b/src/rcnn/trainer.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 from src.rcnn.data import process_data
-from src.rcnn.model import mdl_rpn
+from src.rcnn.model import get_rpn_model
 from src.rcnn.risk import risk_rpn_batch
 
 optimizer = tf.keras.optimizers.Adam()
@@ -27,29 +27,50 @@ ds_test = ds_test.map(
 
 
 @tf.function
-def train_rpn_step(images: tf.Tensor, bx_gt: tf.Tensor) -> None:
+def train_rpn_step(
+    model: tf.keras.Model,
+    images: tf.Tensor,
+    bx_gt: tf.Tensor,
+) -> None:
     """Train RPN for one step.
 
     Args:
+        model (tf.keras.Model): RPN model.
         images (tf.Tensor): images (B, H, W, 3)
         bx_gt (tf.Tensor): ground truth boxes (B, N_gt, 4)
     """
     with tf.GradientTape() as tape:
-        bx_del, logits = mdl_rpn(images, training=True)
+        bx_del, logits = model(images, training=True)
         loss = risk_rpn_batch(bx_del, logits, bx_gt)
-    grads = tape.gradient(loss, mdl_rpn.trainable_variables)
+    grads = tape.gradient(loss, model.trainable_variables)
     optimizer.apply_gradients(
         zip(  # noqa: B905
             grads,
-            mdl_rpn.trainable_variables,
+            model.trainable_variables,
         ))
     train_loss(loss)
 
 
-if __name__ == "__main__":
-    for epoch in range(5):
+def train_rpn(
+    ds_train: tf.data.Dataset,
+    ds_test: tf.data.Dataset,
+    epochs: int,
+) -> None:
+    """Train RPN.
+
+    Args:
+        ds_train (tf.data.Dataset): training dataset.
+        ds_test (tf.data.Dataset): testing dataset.
+        epochs (int): number of epochs.
+    """
+    model = get_rpn_model()
+    for epoch in range(epochs):
         # Reset the metrics at the start of the next epoch
         train_loss.reset_states()
         for img, bx, _ in ds_train:
-            train_rpn_step(img, bx)
+            train_rpn_step(model, img, bx)
             print(f"training loss: {train_loss.result()}")
+
+
+if __name__ == "__main__":
+    train_rpn(ds_train, ds_test, 1)

--- a/tests/test_rcnn_box_anchor.py
+++ b/tests/test_rcnn_box_anchor.py
@@ -1,7 +1,7 @@
 """Test Faster R-CNN `box` module."""
 import tensorflow as tf
 
-from src.rcnn.box import anchor
+from src.rcnn.box import abs_anchors
 from src.rcnn.box import bbox
 
 EPS = 1e-3
@@ -12,7 +12,7 @@ def test_box_anchor() -> None:
     # pre-defined anchors of ratio 1:1
     h = 24
     w = 32
-    pre_anchor = anchor(h, w, 32)
+    pre_anchor = abs_anchors(h, w, 32)
     pre_anchor_11 = pre_anchor[:, :, 3:6, :]
     res = bbox.xmax(pre_anchor_11) - bbox.xmin(pre_anchor_11)
     exp = tf.tile(

--- a/tests/test_rcnn_box_bbox.py
+++ b/tests/test_rcnn_box_bbox.py
@@ -37,3 +37,30 @@ def test_box_bbox_trans_random(bx: tf.Tensor) -> None:
     xywh = box.bbox.to_xywh(bx)
     res = box.bbox.from_xywh(xywh)
     assert tf.get_static_value(tf.reduce_all(tf.math.abs(res - bx) < EPS))
+
+
+def test_box_bbox_clip():
+    # Create a bounding box tensor
+    bbox = tf.constant([
+        [10.0, 10.0, 30.0, 30.0, 0.6],  # within
+        [-10.0, -10.0, 30.0, 30.0, 0.8],  # partly outside (top-left)
+        [10.0, 10.0, 130.0, 130.0, 0.9],  # partly outside (bottom-right)
+        [-10.0, -10.0, 130.0, 130.0, 0.7],  # completely outside
+    ])
+
+    # Set image dimensions
+    h, w = 100.0, 100.0
+
+    # Expected output
+    expected_output = tf.constant([
+        [10.0, 10.0, 30.0, 30.0, 0.6],
+        [0.0, 0.0, 30.0, 30.0, 0.8],
+        [10.0, 10.0, 100.0, 100.0, 0.9],
+        [0.0, 0.0, 100.0, 100.0, 0.7],
+    ])
+
+    # Call clip function
+    output = box.bbox.clip(bbox, h, w)
+
+    # Check if the output matches the expected output
+    assert tf.reduce_all(tf.equal(output, expected_output))

--- a/tests/test_rcnn_box_utils.py
+++ b/tests/test_rcnn_box_utils.py
@@ -1,7 +1,7 @@
 """Test utils of `rcnn.box`."""
 import tensorflow as tf
 
-from src.rcnn.box import anchor
+from src.rcnn.box import abs_anchors
 from src.rcnn.box import bbox2delta
 from src.rcnn.box import delta2bbox
 
@@ -10,7 +10,7 @@ EPS = 1e-3
 
 def test_box_bbox_delta() -> None:
     """Test `bbox2delta` and `delta2bbox`."""
-    anchors = anchor(3, 4, 16)
+    anchors = abs_anchors(3, 4, 16)
     diff = tf.random.uniform((3, 4, 9, 4))
     bx = delta2bbox(anchors, diff)  # anchors + diff = bx
     diff2 = bbox2delta(bx, anchors)  # bx - anchors = diff2

--- a/tests/test_rcnn_model_rpn.py
+++ b/tests/test_rcnn_model_rpn.py
@@ -2,12 +2,13 @@
 import tensorflow as tf
 from tensorflow.keras.models import Model
 
-from src.rcnn.model import mdl_rpn
+from src.rcnn.model import get_rpn_model
 
 
 def setup_model() -> Model:
     """Set up the model."""
     # model = VGG16 + RPN
+    mdl_rpn = get_rpn_model()
     mdl_rpn.compile(optimizer="adam", loss="mse")
     return mdl_rpn
 


### PR DESCRIPTION
- `model`
  - add RoI model
  - expose model factories instead of model instances
  - rename `RPN` to `ProposalBlock`
- `box`
  - add `bbox.clip`
  - relative coordinates `anchors` as a variable
- add RPN trainer
